### PR TITLE
First tamir commit + small comment display change (include comment author and date)

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,5 +1,11 @@
 class ApplicationComponent < ViewComponent::Base
   include SettingsHelper
+  include ActionView::Helpers::TranslationHelper
+
+  def t(key = nil, **options)
+    ActionView::Helpers::TranslationHelper.instance_method(:t).bind(self).call(key, **options)
+  end
+ 
   delegate :back_link_to, to: :helpers
   delegate :default_form_builder, to: :controller
 end

--- a/app/views/legislation/annotations/_comments.html.erb
+++ b/app/views/legislation/annotations/_comments.html.erb
@@ -2,6 +2,12 @@
    limit(Legislation::Annotation::COMMENTS_PAGE_SIZE).each do |comment| %>
   <div class="comment">
     <div class="comment-text">
+      <strong>
+        <%= comment.user&.name || t("comments.comment.user_deleted") %>
+        <span style="font-weight: normal; color: #888;">
+          (<%= comment.created_at.strftime('%d/%m/%Y') %>)
+        </span>:
+      </strong>
       <p><%= truncate comment.body, length: 250 %></p>
     </div>
     <div class="comment-meta">

--- a/config/locales/he/legislation.yml
+++ b/config/locales/he/legislation.yml
@@ -3,7 +3,7 @@ he:
     annotations:
       comments:
         see_all: הצג הכל
-        see_complete: ראה כולל
+        see_complete: ראה עוד
         replies_count:
           one: "%{count} תגובה"
           two: "%{count} תגובות"


### PR DESCRIPTION
## References

First Tamir push

## Objectives

To enable Tamir Levy to push updates and to add comment author and date when reviewing legislation suggestions.
I had to add the explicit t() override in application_component.rb otherwise, t() defaults to I18n.t() which uses only .yml files and not the DB. (Not in all parts but definitely in footer_component.html.erb)
## Visual Changes

![image](https://github.com/user-attachments/assets/bef3c8b6-b932-4f2b-86d3-c148083241af)

## Notes

I hope I am doing this PR correctly...:)